### PR TITLE
Add docs link for WebLink

### DIFF
--- a/components.yml
+++ b/components.yml
@@ -285,7 +285,7 @@ VarDumper:
 
 WebLink:
     slug: web-link
-    docUrl: ~
+    docUrl: weblink.html
     deprecated: false
     description: |
         Implements HTML5 Links, Preload and Resource Hints specifications to

--- a/components.yml
+++ b/components.yml
@@ -285,7 +285,7 @@ VarDumper:
 
 WebLink:
     slug: web-link
-    docUrl: weblink.html
+    docUrl: web_link.html
     deprecated: false
     description: |
         Implements HTML5 Links, Preload and Resource Hints specifications to


### PR DESCRIPTION
There is an inconsistency with other components, the page slug in the docs should be `web_link` and not `weblink`. Should I change this or should we keep it as is @javiereguiluz?