### PR TITLE
Removed a duplicated project

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -84,7 +84,6 @@ default:
     - easybook
     - flarum
     - goutte
-    - kunstmaanbundles
     - ladybug
     - matomo
     - mautic


### PR DESCRIPTION
This project is already included in the CMS category, so there's no need to add it to the default list too.