### PR TITLE
Fixed some project URLs

### DIFF
--- a/projects/codeception.yml
+++ b/projects/codeception.yml
@@ -1,7 +1,7 @@
 name: Codeception
 url: http://codeception.com/
 dependencies:
-    - https://github.com/Codeception/Codeception/blob/master/composer.json
+    - https://github.com/Codeception/Codeception/blob/4.0/composer.json
 description: |
     Codeception is a full-stack testing framework which incorporates
     acceptance, functional, and unit testing. It uses a simple PHP DSL to

--- a/projects/eccube.yml
+++ b/projects/eccube.yml
@@ -1,7 +1,7 @@
 name: EC-CUBE
 url: http://www.ec-cube.net/
 dependencies:
-    - https://github.com/EC-CUBE/ec-cube/blob/master/composer.json
+    - https://github.com/EC-CUBE/ec-cube/blob/4.0/composer.json
 description: |
     EC-CUBE is an open source package used to build e-commerce sites.  It is the
     most popular shopping cart system in Japan. Since the release of the

--- a/projects/magento.yml
+++ b/projects/magento.yml
@@ -1,7 +1,7 @@
 name: Magento
 url: http://magento.com
 dependencies:
-    - https://github.com/magento/magento2/blob/develop/composer.json
+    - https://github.com/magento/magento2/blob/2.3/composer.json
     - https://github.com/magento/magento-composer-installer/blob/master/composer.json
 description: |
     Magento offers flexible, scalable eCommerce solutions designed to help

--- a/projects/sulu.yml
+++ b/projects/sulu.yml
@@ -1,7 +1,7 @@
 name: Sulu
 url: http://sulu.io
 dependencies:
-    - https://github.com/sulu/sulu/blob/develop/composer.json
+    - https://github.com/sulu/sulu/blob/master/composer.json
 description: |
     Sulu is a content management platform based on Symfony made for
     businesses. It's a flexible CMS to create and manage enterprise


### PR DESCRIPTION
We changed symfony.com code a bit to not rely on GitHub selecting the default branch to get the file content (we can't do that because some projects don't have the composer.json file in the same location in the default branch).

So, we now always use the exact branch defined in this repository. So, let's update some URLs which weren't correct.