### PR TITLE
Added a new option to configure component's doc page

### DIFF
--- a/components.yml
+++ b/components.yml
@@ -5,6 +5,7 @@
 Asset:
     slug: asset
     docUrl: asset.html
+    docPage: components/asset
     deprecated: false
     description: |
         Manages URL generation and versioning of web assets such as CSS
@@ -13,6 +14,7 @@ Asset:
 BrowserKit:
     slug: browser-kit
     docUrl: browser_kit.html
+    docPage: components/browser_kit
     deprecated: false
     description: |
         Simulates the behavior of a web browser.
@@ -20,6 +22,7 @@ BrowserKit:
 Cache:
     slug: cache
     docUrl: cache.html
+    docPage: components/cache
     deprecated: false
     description: |
         Implements PSR-6 and PSR-16 caching mechanisms and provides adapters for
@@ -28,6 +31,7 @@ Cache:
 ClassLoader:
     slug: class-loader
     docUrl: class_loader.html
+    docPage: components/class_loader
     deprecated: false
     description: |
         Loads your project classes automatically if they follow some standard
@@ -36,6 +40,7 @@ ClassLoader:
 Config:
     slug: config
     docUrl: config.html
+    docPage: components/config
     deprecated: false
     description: |
         Helps you find, load, combine, autofill and validate configuration values.
@@ -43,6 +48,7 @@ Config:
 Console:
     slug: console
     docUrl: console.html
+    docPage: components/console
     deprecated: false
     description: |
         Eases the creation of beautiful and testable command line interfaces.
@@ -50,6 +56,7 @@ Console:
 Contracts:
     slug: contracts
     docUrl: contracts.html
+    docPage: components/contracts
     deprecated: false
     description: |
         A set of abstractions extracted out of the Symfony components.
@@ -57,6 +64,7 @@ Contracts:
 CssSelector:
     slug: css-selector
     docUrl: css_selector.html
+    docPage: components/css_selector
     deprecated: false
     description: |
         Converts CSS selectors to XPath expressions.
@@ -64,6 +72,7 @@ CssSelector:
 Debug:
     slug: debug
     docUrl: debug.html
+    docPage: components/debug
     deprecated: true
     description: |
         Provides tools to ease debugging PHP code.
@@ -71,6 +80,7 @@ Debug:
 DependencyInjection:
     slug: dependency-injection
     docUrl: dependency_injection.html
+    docPage: components/dependency_injection
     deprecated: false
     description: |
         Allows you to standardize and centralize the way objects are constructed
@@ -79,6 +89,7 @@ DependencyInjection:
 Dotenv:
     slug: dotenv
     docUrl: dotenv.html
+    docPage: components/dotenv
     deprecated: false
     description: |
         Parses .env files to make environment variables stored in them accessible
@@ -87,6 +98,7 @@ Dotenv:
 DomCrawler:
     slug: dom-crawler
     docUrl: dom_crawler.html
+    docPage: components/dom_crawler
     deprecated: false
     description: |
         Eases DOM navigation for HTML and XML documents.
@@ -94,6 +106,7 @@ DomCrawler:
 ErrorHandler:
     slug: error-handler
     docUrl: error_handler.html
+    docPage: components/error_handler
     deprecated: false
     description: |
         Provides tools to manage errors and ease debugging PHP code.
@@ -101,6 +114,7 @@ ErrorHandler:
 EventDispatcher:
     slug: event-dispatcher
     docUrl: event_dispatcher.html
+    docPage: components/event_dispatcher
     deprecated: false
     description: |
         Implements the Mediator pattern in a simple and effective way to make
@@ -109,6 +123,7 @@ EventDispatcher:
 ExpressionLanguage:
     slug: expression-language
     docUrl: expression_language.html
+    docPage: components/expression_language
     deprecated: false
     description: |
         Provides an engine that can compile and evaluate expressions.
@@ -116,6 +131,7 @@ ExpressionLanguage:
 Filesystem:
     slug: filesystem
     docUrl: filesystem.html
+    docPage: components/filesystem
     deprecated: false
     description: |
         Provides basic utilities for the filesystem.
@@ -123,6 +139,7 @@ Filesystem:
 Finder:
     slug: finder
     docUrl: finder.html
+    docPage: components/finder
     deprecated: false
     description: |
         Finds files and directories via an intuitive fluent interface.
@@ -130,6 +147,7 @@ Finder:
 Form:
     slug: form
     docUrl: form.html
+    docPage: components/form
     deprecated: false
     description: |
         Provides tools to easy creating, processing and reusing HTML forms.
@@ -137,6 +155,7 @@ Form:
 Guard:
     slug: security-guard
     docUrl: ~
+    docPage: ~
     deprecated: false
     description: |
         Brings many layers of authentication together, making it much easier to
@@ -145,6 +164,7 @@ Guard:
 HttpClient:
     slug: http-client
     docUrl: http_client.html
+    docPage: components/http_client
     deprecated: false
     description: |
         A low-level HTTP client with support for both PHP stream wrappers and
@@ -153,6 +173,7 @@ HttpClient:
 HttpFoundation:
     slug: http-foundation
     docUrl: http_foundation.html
+    docPage: components/http_foundation
     deprecated: false
     description: |
         Defines an object-oriented layer for the HTTP specification.
@@ -160,6 +181,7 @@ HttpFoundation:
 HttpKernel:
     slug: http-kernel
     docUrl: http_kernel.html
+    docPage: components/http_kernel
     deprecated: false
     description: |
         Provides the building blocks to create flexible and fast HTTP-based
@@ -168,6 +190,7 @@ HttpKernel:
 Icu:
     slug: icu
     docUrl: ~
+    docPage: ~
     deprecated: true
     description: |
         Contains the data of the ICU library in a specific version. This component
@@ -176,6 +199,7 @@ Icu:
 Inflector:
     slug: inflector
     docUrl: inflector.html
+    docPage: components/inflector
     deprecated: false
     description: |
         Converts English words between their singular and plural forms.
@@ -183,6 +207,7 @@ Inflector:
 Intl:
     slug: intl
     docUrl: intl.html
+    docPage: components/intl
     deprecated: false
     description: |
         Provides fallback code to handle cases when the intl extension is missing.
@@ -190,6 +215,7 @@ Intl:
 Ldap:
     slug: ldap
     docUrl: ldap.html
+    docPage: components/ldap
     deprecated: false
     description: |
         Provides an LDAP client for PHP on top of PHP's ldap extension.
@@ -197,6 +223,7 @@ Ldap:
 Locale:
     slug: locale
     docUrl: locale.html
+    docPage: components/locale
     deprecated: true
     description: |
         Provides fallback code to handle cases when the intl extension is missing.
@@ -205,6 +232,7 @@ Locale:
 Lock:
     slug: lock
     docUrl: lock.html
+    docPage: components/lock
     deprecated: false
     description: |
         Creates and manages locks, a mechanism to provide exclusive access to a
@@ -213,6 +241,7 @@ Lock:
 Mailer:
     slug: mailer
     docUrl: mailer.html
+    docPage: components/mailer
     deprecated: false
     description: |
         Helps sending emails and provides integration with the most popular
@@ -221,6 +250,7 @@ Mailer:
 Messenger:
     slug: messenger
     docUrl: messenger.html
+    docPage: components/messenger
     deprecated: false
     description: |
         Helps applications send and receive messages to/from other applications
@@ -229,6 +259,7 @@ Messenger:
 Mime:
     slug: mime
     docUrl: mime.html
+    docPage: components/mime
     deprecated: false
     description: |
         Allows manipulating MIME messages, used to create advanced email
@@ -237,6 +268,7 @@ Mime:
 Notifier:
     slug: notifier
     docUrl: ~
+    docPage: ~
     deprecated: false
     description: |
         Sends notifications via one or more channels (email, SMS, Slack, Telegram, ...)
@@ -244,6 +276,7 @@ Notifier:
 OptionsResolver:
     slug: options-resolver
     docUrl: options_resolver.html
+    docPage: components/options_resolver
     deprecated: false
     description: |
         Helps you configuring objects with option arrays.
@@ -251,6 +284,7 @@ OptionsResolver:
 Process:
     slug: process
     docUrl: process.html
+    docPage: components/process
     deprecated: false
     description: |
         Executes commands in sub-processes.
@@ -258,6 +292,7 @@ Process:
 PropertyAccess:
     slug: property-access
     docUrl: property_access.html
+    docPage: components/property_access
     deprecated: false
     description: |
         Provides function to read and write from/to an object or array using a
@@ -266,6 +301,7 @@ PropertyAccess:
 PropertyInfo:
     slug: property-info
     docUrl: property_info.html
+    docPage: components/property_info
     deprecated: false
     description: |
         Extracts information about the properties of PHP classes using metadata
@@ -274,6 +310,7 @@ PropertyInfo:
 Routing:
     slug: routing
     docUrl: routing.html
+    docPage: components/routing
     deprecated: false
     description: |
         Maps an HTTP request to a set of configuration variables.
@@ -281,6 +318,7 @@ Routing:
 Security:
     slug: security
     docUrl: security.html
+    docPage: components/security
     deprecated: false
     description: |
         Provides an infrastructure for sophisticated authorization systems.
@@ -288,6 +326,7 @@ Security:
 Serializer:
     slug: serializer
     docUrl: serializer.html
+    docPage: components/serializer
     deprecated: false
     description: |
         Turns objects into a specific format (XML, JSON, Yaml, ...) and the
@@ -296,6 +335,7 @@ Serializer:
 Stopwatch:
     slug: stopwatch
     docUrl: stopwatch.html
+    docPage: components/stopwatch
     deprecated: false
     description: |
         Provides a way to profile code.
@@ -303,6 +343,7 @@ Stopwatch:
 String:
     slug: string
     docUrl: string.html
+    docPage: components/string
     deprecated: false
     description: |
         Provides an object-oriented API to strings and deals with bytes, UTF-8
@@ -311,6 +352,7 @@ String:
 Templating:
     slug: templating
     docUrl: templating.html
+    docPage: components/templating
     deprecated: false
     description: |
         Provides all the tools needed to build any kind of template system.
@@ -318,6 +360,7 @@ Templating:
 Translation:
     slug: translation
     docUrl: translation.html
+    docPage: components/translation
     deprecated: false
     description: |
         Provides tools to internationalize your application.
@@ -325,6 +368,7 @@ Translation:
 Validator:
     slug: validator
     docUrl: validator.html
+    docPage: components/validator
     deprecated: false
     description: |
         Provides tools to validate classes.
@@ -332,6 +376,7 @@ Validator:
 VarDumper:
     slug: var-dumper
     docUrl: var_dumper.html
+    docPage: components/var_dumper
     deprecated: false
     description: |
         Provides mechanisms for walking through any arbitrary PHP variable.
@@ -339,6 +384,7 @@ VarDumper:
 VarExporter:
     slug: var-exporter
     docUrl: var_exporter.html
+    docPage: components/var_exporter
     deprecated: false
     description: |
         Exports any serializable PHP data structure to plain PHP code and allows
@@ -347,6 +393,7 @@ VarExporter:
 WebLink:
     slug: web-link
     docUrl: web_link.html
+    docPage: components/web_link
     deprecated: false
     description: |
         Implements HTML5 Links, Preload and Resource Hints specifications to
@@ -356,6 +403,7 @@ WebLink:
 'Webpack Encore':
     slug: webpack-encore
     docUrl: frontend.html
+    docPage: frontend
     deprecated: false
     description: |
         A simpler way to integrate Webpack into your application, giving you a
@@ -365,6 +413,7 @@ WebLink:
 Workflow:
     slug: workflow
     docUrl: workflow.html
+    docPage: components/workflow
     deprecated: false
     description: |
         Provides tools for managing a workflow or finite state machine.
@@ -372,6 +421,7 @@ Workflow:
 Yaml:
     slug: yaml
     docUrl: yaml.html
+    docPage: components/yaml
     deprecated: false
     description: |
         Loads and dumps YAML files.
@@ -379,6 +429,7 @@ Yaml:
 'PHPUnit Bridge':
     slug: phpunit-bridge
     docUrl: phpunit_bridge.html
+    docPage: components/phpunit_bridge
     deprecated: false
     description: |
         Provides utilities to report legacy tests and usage of deprecated code
@@ -387,6 +438,7 @@ Yaml:
 'Polyfill APCu':
     slug: polyfill-apcu
     docUrl: polyfill_apcu.html
+    docPage: components/polyfill_apcu
     deprecated: false
     description: |
         Provides apcu_* functions and the APCUIterator class to users of the
@@ -395,6 +447,7 @@ Yaml:
 'Polyfill Ctype':
     slug: polyfill-ctype
     docUrl: polyfill_ctype.html
+    docPage: components/polyfill_ctype
     deprecated: false
     description: |
         Provides a partial, native PHP implementation for the ctype extension.
@@ -402,6 +455,7 @@ Yaml:
 'Polyfill PHP 5.4':
     slug: polyfill-php54
     docUrl: polyfill_php54.html
+    docPage: components/polyfill_php54
     deprecated: false
     description: |
         Provides functions unavailable in releases prior to PHP 5.4.
@@ -409,6 +463,7 @@ Yaml:
 'Polyfill PHP 5.5':
     slug: polyfill-php55
     docUrl: polyfill_php55.html
+    docPage: components/polyfill_php55
     deprecated: false
     description: |
         Provides functions unavailable in releases prior to PHP 5.5.
@@ -416,6 +471,7 @@ Yaml:
 'Polyfill PHP 5.6':
     slug: polyfill-php56
     docUrl: polyfill_php56.html
+    docPage: components/polyfill_php56
     deprecated: false
     description: |
         Provides functions unavailable in releases prior to PHP 5.6.
@@ -423,6 +479,7 @@ Yaml:
 'Polyfill PHP 7.0':
     slug: polyfill-php70
     docUrl: polyfill_php70.html
+    docPage: components/polyfill_php70
     deprecated: false
     description: |
         Provides functions unavailable in releases prior to PHP 7.0.
@@ -430,6 +487,7 @@ Yaml:
 'Polyfill PHP 7.1':
     slug: polyfill-php71
     docUrl: polyfill_php71.html
+    docPage: components/polyfill_php71
     deprecated: false
     description: |
         Provides functions unavailable in releases prior to PHP 7.1.
@@ -437,6 +495,7 @@ Yaml:
 'Polyfill PHP 7.2':
     slug: polyfill-php72
     docUrl: polyfill_php72.html
+    docPage: components/polyfill_php72
     deprecated: false
     description: |
         Provides functions unavailable in releases prior to PHP 7.2.
@@ -444,6 +503,7 @@ Yaml:
 'Polyfill PHP 7.3':
     slug: polyfill-php73
     docUrl: polyfill_php73.html
+    docPage: components/polyfill_php73
     deprecated: false
     description: |
         Provides functions unavailable in releases prior to PHP 7.3.
@@ -451,6 +511,7 @@ Yaml:
 'Polyfill Iconv':
     slug: polyfill-iconv
     docUrl: polyfill_iconv.html
+    docPage: components/polyfill_iconv
     deprecated: false
     description: |
         Provides a native PHP implementation of the php.net/iconv functions.
@@ -458,6 +519,7 @@ Yaml:
 'Polyfill Intl Grapheme':
     slug: polyfill-intl-grapheme
     docUrl: polyfill_intl_grapheme.html
+    docPage: components/polyfill_intl_grapheme
     deprecated: false
     description: |
         Provides a partial, native PHP implementation of the Grapheme functions
@@ -466,6 +528,7 @@ Yaml:
 'Polyfill Intl ICU':
     slug: polyfill-intl-icu
     docUrl: polyfill_intl_icu.html
+    docPage: components/polyfill_intl_icu
     deprecated: false
     description: |
         Provides a collection of functions/classes using the symfony/intl
@@ -474,6 +537,7 @@ Yaml:
 'Polyfill Intl IDN':
     slug: polyfill-intl-idn
     docUrl: polyfill_intl_idn.html
+    docPage: components/polyfill_intl_idn
     deprecated: false
     description: |
         Provides a collection of functions related to IDN when the Intl
@@ -482,6 +546,7 @@ Yaml:
 'Polyfill Intl MessageFormatter':
     slug: polyfill-intl-messageformatter
     docUrl: polyfill_intl_messageformatter.html
+    docPage: components/polyfill_intl_messageformatter
     deprecated: false
     description: |
         Provides a fallback implementation for the MessageFormatter class
@@ -490,6 +555,7 @@ Yaml:
 'Polyfill Intl Normalizer':
     slug: polyfill-intl-normalizer
     docUrl: polyfill_intl_normalizer.html
+    docPage: components/polyfill_intl_normalizer
     deprecated: false
     description: |
         Provides a fallback implementation for the Normalizer class provided by
@@ -498,6 +564,7 @@ Yaml:
 'Polyfill Mbstring':
     slug: polyfill-mbstring
     docUrl: polyfill_mbstring.html
+    docPage: components/polyfill_mbstring
     deprecated: false
     description: |
         Provides a partial, native PHP implementation for the Mbstring extension.
@@ -505,6 +572,7 @@ Yaml:
 'Polyfill Util':
     slug: polyfill-util
     docUrl: ~
+    docPage: ~
     deprecated: false
     description: |
         Provides binary-safe string functions, using the mbstring extension
@@ -513,6 +581,7 @@ Yaml:
 'Polyfill UUID':
     slug: polyfill-uuid
     docUrl: polyfill_uuid.html
+    docPage: components/polyfill_uuid
     deprecated: false
     description: |
         Provides a native PHP implementation for the UUID extension.
@@ -520,6 +589,7 @@ Yaml:
 'Polyfill Xml':
     slug: polyfill-xml
     docUrl: ~
+    docPage: components/polyfill_xml
     deprecated: true
     description: |
         Provides a fallback implementation for the following functions in the

--- a/validator.php
+++ b/validator.php
@@ -117,7 +117,7 @@ final class Validate extends Command
         }
 
         // check that components define some mandatory properties
-        $mandatoryProperties = ['slug', 'docUrl', 'deprecated', 'description'];
+        $mandatoryProperties = ['slug', 'docUrl', 'docPage', 'deprecated', 'description'];
         foreach ($components as $componentName => $componentData) {
             if (array_keys($componentData) !== $mandatoryProperties) {
                 $io->error(sprintf('The "%s" component must only define the following mandatory properties: "%s".', $componentName, implode(', ', $mandatoryProperties)));


### PR DESCRIPTION
In the past we assumed that all component docs were under `/doc/current/component/<component-slug>.html` ... but that's no longer true. "Webpack Encore" for example is under `/doc/current/frontend.html` and things will change quickly for other components.

Once this is merged, we'l update symfony.com code ... and once that's completed, we can remove the unused `docUrl` config from this file.