### PR TITLE
Remove the doc page for the deprecated templating component

### DIFF
--- a/components.yml
+++ b/components.yml
@@ -343,7 +343,7 @@ String:
 
 Templating:
     slug: templating
-    docPage: templates
+    docPage: null
     deprecated: false
     description: |
         Provides all the tools needed to build any kind of template system.


### PR DESCRIPTION
Due to the deprecation, the `templates` doc page has been rewritten entirely to use Twig rather than the templating component.