### PR TITLE
Update link to Stopwatch component docs

### DIFF
--- a/components.yml
+++ b/components.yml
@@ -88,7 +88,7 @@ Dotenv:
 
 DomCrawler:
     slug: dom-crawler
-    docPage: performance#profiling-symfony-applications
+    docPage: components/dom_crawler
     deprecated: false
     description: |
         Eases DOM navigation for HTML and XML documents.
@@ -330,7 +330,7 @@ Serializer:
 
 Stopwatch:
     slug: stopwatch
-    docPage: components/stopwatch
+    docPage: performance#profiling-symfony-applications
     deprecated: false
     description: |
         Provides a way to profile code.

--- a/components.yml
+++ b/components.yml
@@ -88,7 +88,7 @@ Dotenv:
 
 DomCrawler:
     slug: dom-crawler
-    docPage: components/dom_crawler
+    docPage: performance#profiling-symfony-applications
     deprecated: false
     description: |
         Eases DOM navigation for HTML and XML documents.


### PR DESCRIPTION
I'm going to check symfony.com code to see if we support fragments in these URLs like we do in the Docs section of the site and I'll add support if we don't.